### PR TITLE
adding schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ parameters-sf*.*
 update-streams-sf*/
 update-streams-sf*.*
 initial-snapshot/*
+
+postgres/data/**

--- a/typeql/loader.py
+++ b/typeql/loader.py
@@ -1,0 +1,45 @@
+from typedb.client import *
+import csv
+from typedb.api.connection.transaction import TypeDBTransactionType
+
+# Connect to the TypeDB server
+with TypeDB.core_client("localhost:1729") as client:
+    with client.session("try2", SessionType.DATA) as session:
+        ## creating a write transaction
+        pass
+
+def insert_data(tx, data):
+    query = f"""
+    insert $person isa person,
+        has creationDate "{data['creationDate']}",
+        has id {data['id']},
+        has firstName "{data['firstName']}",
+        has lastName "{data['lastName']}",
+        has gender "{data['gender']}",
+        has birthday "{data['birthday']}",
+        has locationIP "{data['locationIP']}",
+        has browserUsed "{data['browserUsed']}",
+        has language "{data['language']}",
+        has email "{data['email']}";
+    """
+    tx.query().insert(query)
+
+    
+
+csv_data = """
+creationDate|id|firstName|lastName|gender|birthday|locationIP|browserUsed|LocationCityId|language|email
+2010-01-31T13:13:03.929+00:00|16|Jan|Zakrzewski|female|1986-07-05|31.41.169.140|Chrome|1284|pl;en|Jan16@hotmail.com;Jan16@gmx.com;Jan16@gmail.com;Jan16@chemist.com;Jan16@yahoo.com
+"""
+
+lines = csv_data.strip().split("\n")
+headers = lines[0].split("|")
+
+for line in lines[1:]:
+    values = line.split("|")
+    data = {headers[i]: values[i] for i in range(len(headers))}
+    with session.transaction(TypeDBTransactionType.WRITE) as tx:
+        insert_data(tx, data)
+        tx.commit()
+
+session.close()
+client.close()

--- a/typeql/schema.tql
+++ b/typeql/schema.tql
@@ -1,0 +1,218 @@
+define 
+
+#entities
+
+City sub Place,
+    plays isLocatedIn:locatedIn,
+    plays isPartOf:part;
+
+Country sub Place,
+    plays isLocatedIn:locatedIn,
+    plays isPartOf:part,
+    plays isPartOf:partOf;
+
+Continent sub Place,
+    plays isPartOf:partOf;
+
+Place sub entity,
+    abstract,
+    owns id @key,
+    owns name,
+    owns url;
+
+Comment sub Message,
+    plays replyOf:reply;
+
+Post sub Message,
+    owns imageFile,
+    owns language,
+    plays containerOf:contain;
+
+Message sub entity,
+    abstract,
+    owns id @key,
+    owns browserUsed,
+    owns creationDate,
+    owns locationIP,
+    owns content,
+    owns length,
+    plays hasCreator:created,
+    plays hasTag:tagged,
+    plays isLocatedIn:location,
+    plays likes:message,
+    plays replyOf:repliedTo;
+
+
+Organisation sub entity,
+    abstract,
+    owns id @key,
+    owns name,
+    owns url;
+
+University sub Organisation,
+    plays isLocatedIn:location,
+    plays studyAt:university;
+
+Company sub Organisation,
+    plays isLocatedIn:location,
+    plays workAt:employer;
+
+Forum sub entity,
+    owns id @key,
+    owns title,
+    owns creationDate,
+    plays containerOf:contain,
+    plays hasMember:memberOf,
+    plays hasModerator:moderated,
+    plays hasTag:tagged;
+
+Person sub entity,
+    owns id @key,
+    owns firstName,
+    owns lastName,
+    owns gender,
+    owns birthday,
+    owns email,
+    owns speaks,
+    owns browserUsed,
+    owns locationIP,
+    owns creationDate,
+    plays hasCreator:creator,
+    plays hasInterest:interested,
+    plays hasMember:member,
+    plays hasModerator:moderator,
+    plays isLocatedIn:location,
+    plays knows:person,
+    plays likes:person,
+    plays studyAt:student,
+    plays workAt:employee;
+
+Tag sub entity,
+    owns id @key,
+    owns name,
+    owns url,
+    plays hasInterest:interests,
+    plays hasTag:tag,
+    plays hasType:tag;
+
+TagClass sub entity,
+    owns id @key,
+    owns name,
+    owns url,
+    plays hasType:tagClass,
+    plays isSubclassOf:subclass;
+
+#attributes
+
+name sub attribute,
+    value string;
+    
+id sub attribute,
+    value long;
+
+firstName sub attribute,
+    value string;
+
+lastName sub attribute,
+    value string;
+
+gender sub attribute,
+    value string;
+
+birthday sub attribute,
+    value datetime;
+
+speaks sub attribute,
+    value string;
+
+email sub attribute,
+    value string;
+
+url sub attribute,
+    value string;
+
+browserUsed sub attribute,
+    value string;
+
+locationIP sub attribute,
+    value string;
+
+content sub attribute,
+    value string;
+
+length sub attribute,
+    value long;
+
+title sub attribute,
+    value string;
+
+creationDate sub attribute,
+    value datetime;
+
+language sub attribute,
+    value string;
+
+imageFile sub attribute,
+    value string;
+
+
+#relations
+
+containerOf sub relation,
+    relates contain,
+    relates container;
+
+hasCreator sub relation,
+    relates creator,
+    relates created;
+
+hasInterest sub relation,
+    relates interested,
+    relates interests;
+
+hasMember sub relation,
+    relates member,
+    relates memberOf;
+
+hasModerator sub relation,
+    relates moderator,
+    relates moderated;
+
+hasTag sub relation,
+    relates tag,
+    relates tagged;
+
+hasType sub relation,
+    relates tag,
+    relates tagClass;
+
+isLocatedIn sub relation,
+    relates location,
+    relates locatedIn;
+
+isPartOf sub relation,
+    relates part,
+    relates partOf;
+
+isSubclassOf sub relation,
+    relates subclass,
+    relates superclass;
+
+knows sub relation,
+    relates person;
+
+likes sub relation,
+    relates person,
+    relates message;
+
+replyOf sub relation,
+    relates reply,
+    relates repliedTo;
+
+studyAt sub relation,
+    relates student,
+    relates university;
+
+workAt sub relation,
+    relates employee,
+    relates employer;


### PR DESCRIPTION
From @krishnangovindraj to me:

Most of these come from me just looking at the ER diagram rather than your schema:
* Do you see a reason why we shouldn't let the organisation itself have a "isLocatedIn" field? I know the ER diagram puts it on the university & company, but TypeQL can do better.
* It might be risky to have a single `isPartOf` for City->Country and Country->Continent arrow. We may want to create an abstract base relation. We could also ask for advice in the `#schema` learning channel to know what the research engineers recommend.
* For `isLocatedIn` I think we should have an abstract base relation, and possibly 3 sub-relations. I think these are questions worth asking on the schema channel, because I'm not sure what's best practice.
* I don't know if `knows` is a symmetric relation. Could you verify? (E.g. on facebook, friends is symmetric but follows is not) 
* I'm a little tempted to go for more typeql style names for the relations & roles.  e.g. `hasCreator` could be a `created-by`. Though there is merit in sticking to the standard names for a standard benchmark, the typeql version of the code is less readable if we stick to those names - See the end for my reasoning.
* Can you rearrange the declarations so the base classes come before the subclasses? (e.g. Message coming before post & comment)

Some of these might be a result of typeql just being more expressive than standard ER diagrams. If it is, it's a valid reason to extend benchmarks.

**Why I'd go for typeql style names**
Consider the `containerOf` relation. It's declaration sits by itself.
```
containerOf sub relation,
    relates contain,
    relates container;
```

Whereas in sql, it would sit in the CREATE TABLE command for the forum
`CREATE TABLE forum, ..., containerOf LONG, FOREIGN KEY (containerOf) REFERENCES Post(Id)`

A more typeql style name could be:
```
posted-in sub relation,
    relates post,
    relates forum;
```